### PR TITLE
Fix/owner gets message

### DIFF
--- a/libs/actions/private.js
+++ b/libs/actions/private.js
@@ -47,6 +47,9 @@ module.exports = (config,{x2100,users,messages,threads})=>{
         // get followers; this excludes the owner
         const qualified = await actions.followers(tokenid, threshold)
 
+        //add message to owners feed
+        await threads.create({threadid:user.id,messageid:message.id})
+
         //add message to tokens feed
         await threads.create({threadid:tokenid,messageid:message.id})
 

--- a/libs/actions/private.js
+++ b/libs/actions/private.js
@@ -13,7 +13,7 @@ module.exports = (config,{x2100,users,messages,threads})=>{
   return user=>{
     assert(user,'you must login')
     const defaultThreshold = user.defaultThreshold || config.defaultThreshold || 0
-    return {
+    const actions = {
       me(){
         return user
       },
@@ -106,5 +106,6 @@ module.exports = (config,{x2100,users,messages,threads})=>{
         })
       }
     }
+    return actions
   }
 }


### PR DESCRIPTION
Use the built in 'private/followers' action to get all followers, add in all the additional recipients of messages (owner, token feed, public feed), send them all at once